### PR TITLE
Fix validation matcher for anyOf

### DIFF
--- a/src/main/kotlin/com/ebay/plugins/graph/analytics/validation/matchers/AnyOfGraphMatcher.kt
+++ b/src/main/kotlin/com/ebay/plugins/graph/analytics/validation/matchers/AnyOfGraphMatcher.kt
@@ -4,7 +4,7 @@ package com.ebay.plugins.graph.analytics.validation.matchers
  * Matcher which matches only if any of the delegate rules match the input.
  */
 internal class AnyOfGraphMatcher<T>(
-    private val delegates: Iterable<GraphMatcher<T>>
+    private val delegates: Iterable<GraphMatcher<in T>>
 ) : GraphMatcher<T> {
     override fun matches(value: T): DescribedMatch {
         // Evaluate all delegates to get a complete description

--- a/src/main/kotlin/com/ebay/plugins/graph/analytics/validation/matchers/GraphMatchers.kt
+++ b/src/main/kotlin/com/ebay/plugins/graph/analytics/validation/matchers/GraphMatchers.kt
@@ -85,7 +85,7 @@ object GraphMatchers {
      * Matcher which matches only if any of the delegate rules match the input.
      */
     @JvmStatic
-    fun <T> anyOf(vararg delegates: GraphMatcher<T>): GraphMatcher<T> {
+    fun <T> anyOf(vararg delegates: GraphMatcher<in T>): GraphMatcher<T> {
         return AnyOfGraphMatcher(delegates.toList())
     }
 


### PR DESCRIPTION
Quick fix to generic definition on the `anyOf` graph validation matcher