### PR TITLE
Reports should use system line separators

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,27 @@ project-specific metrics and rules can greatly extend its capabilities!
 
 For more information, please refer to the [Configuration](docs/Configuration.md) document.
 
+## Integrations
+
+### Metrics for Develocity
+
+Out-of-the-box, this plugin provides project graph information based upon the declared
+structure of the project.  When working to improve build performance, the next questions
+that naturally follow fall along the following lines:
+- How much build time does each project module contribute?
+- How many frequently are project modules built?
+
+To answer these questions, the
+[Metrics for Develocity](https://github.com/eBay/metrics-for-develocity-plugin)
+plugin can be used to gather this information from a
+[Develocity](https://gradle.com/gradle-enterprise-solutions/)
+server instance, layering this data into the project graph analysis performed by
+this plugin.
+
+For more information, see the
+[Project Cost Graph Analytics Integration](https://github.com/eBay/metrics-for-develocity-plugin/tree/main/src/main/kotlin/com/ebay/plugins/metrics/develocity/projectcost#project-cost-graph-analytics-integration)
+document.
+
 ## Contributing
 
 Contributions are welcome!  Please refer to the [CONTRIBUTING](CONTRIBUTING.md) document for

--- a/src/main/kotlin/com/ebay/plugins/graph/analytics/DirectComparisonTask.kt
+++ b/src/main/kotlin/com/ebay/plugins/graph/analytics/DirectComparisonTask.kt
@@ -79,7 +79,9 @@ internal abstract class DirectComparisonTask : BaseGraphPersistenceTask() {
         val afterGraph = DefaultDirectedGraph<VertexInfo, EdgeInfo>(EdgeInfo::class.java)
         persistence.import(afterGraph, afterFile.asFile)
 
-        val report = GraphComparisonHelper().compare(beforeGraph, afterGraph)
+        val report = GraphComparisonHelper()
+            .compare(beforeGraph, afterGraph)
+            .replace("\n", System.lineSeparator())
 
         outputFile.get().asFile.writeText(report)
         logger.lifecycle("Graph analysis comparison report available at: file://${outputFile.asFile.get()}")

--- a/src/main/kotlin/com/ebay/plugins/graph/analytics/InspectionTask.kt
+++ b/src/main/kotlin/com/ebay/plugins/graph/analytics/InspectionTask.kt
@@ -46,7 +46,7 @@ internal abstract class InspectionTask : BaseGraphInputTask() {
             append("Dependency tree:\n")
             addDependency(graph = graph, indent = "", vertex = selfInfo)
             append("* Indicates a vertex that has already been rendered\n")
-        }
+        }.replace("\n", System.lineSeparator())
 
         outputFile.asFile.get().writeText(report)
         logger.lifecycle("Project inspection analysis comparison report available at: file://${outputFile.asFile.get()}")

--- a/src/main/kotlin/com/ebay/plugins/graph/analytics/validation/GraphValidationTask.kt
+++ b/src/main/kotlin/com/ebay/plugins/graph/analytics/validation/GraphValidationTask.kt
@@ -104,7 +104,7 @@ abstract class GraphValidationTask : BaseGraphPersistenceTask() {
 
         val totalReport = validationResults.joinToString(separator = "\n") { validationResult ->
             buildReportString(validationResult)
-        }
+        }.replace("\n", System.lineSeparator())
         outputFile.asFile.get().writeText(totalReport)
 
         val errors = validationResults.filterIsInstance<GraphValidation>()


### PR DESCRIPTION
Also:
- Add cross reference docs pointing at the Metrics for Develocity plugin's Project Cost Graph Analysis integration.

