### PR TITLE
Ensure that consumable configurations are uniquely identified via attribute

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@ org.gradle.daemon=true
 org.gradle.caching=true
 org.gradle.parallel=true
 org.gradle.configuration-cache=true
-version=1.0.1
+version=1.0.2

--- a/src/main/kotlin/com/ebay/plugins/graph/analytics/GraphAnalyticsPlugin.kt
+++ b/src/main/kotlin/com/ebay/plugins/graph/analytics/GraphAnalyticsPlugin.kt
@@ -9,6 +9,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ProjectDependency
+import org.gradle.api.attributes.Attribute
 import org.gradle.api.initialization.Settings
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskProvider
@@ -326,6 +327,7 @@ internal class GraphAnalyticsPlugin : Plugin<Any> {
             isCanBeConsumed = true
             isCanBeResolved = false
             isTransitive = false
+            attributes.attribute(ATTR_CONFIG_TYPE, name)
         }
     }
 
@@ -337,6 +339,15 @@ internal class GraphAnalyticsPlugin : Plugin<Any> {
         const val ANALYSIS_TASK = "graphAnalysis"
         const val DIRECT_COMPARISON_TASK = "graphComparison"
         const val PROJECT_INSPECTION_TASK = "graphInspection"
+
+        /**
+         * Attribute used to disambiguate consumable configurations but something other than
+         * their name.
+         */
+        val ATTR_CONFIG_TYPE: Attribute<String> = Attribute.of(
+            "com.ebay.graph-analytics.type",
+            String::class.java
+        )
 
         private const val GATHER_PROD_DEPENDENCIES_RESOLVE_CONFIGURATION = "graphAnalytics_resolvable_prodDependencies"
         private const val GATHER_PROD_DEPENDENCIES_RESOLVE_TASK = "graphProductionDependencies"


### PR DESCRIPTION
This should resolve integration issues in projects which trigger the following error:
```
Consumable configurations with identical capabilities within a project (other than the default configuration) must have unique attributes, but configuration ':project' and [configuration ':project:graphAnalytics_analysis', configuration ':project:graphAnalytics_consolidatedDependencies', configuration ':project:graphAnalytics_prodDependencies', configuration ':project:graphAnalytics_testDependencies'] contain identical attribute sets. Consider adding an additional attribute to one of the configurations to disambiguate them.  Run the 'outgoingVariants' task for more details. For more information, please refer to https://docs.gradle.org/8.7/userguide/upgrading_version_7.html#unique_attribute_sets in the Gradle documentation.
```

I have not yet figured out a way to repro this situation in a manner which can be automated via testing.
