### PR TITLE
Disable isolated projects for publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,4 +18,4 @@ jobs:
         env:
           GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
           GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
-        run: ./gradlew publishPlugins
+        run: ./gradlew -Dorg.gradle.unsafe.isolated-projects=false --no-configuration-cache publishPlugins

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,4 +18,4 @@ jobs:
         env:
           GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
           GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
-        run: ./gradlew --no-configuration-cache publishPlugins
+        run: ./gradlew publishPlugins


### PR DESCRIPTION
Enabling isolated projects broke the publishing workflow:
```
FAILURE: Build failed with an exception.

* What went wrong:
The configuration cache cannot be disabled when isolated projects is enabled.
```

Explicitly forcing it to disabled for release publishing