### PR TITLE
Support Gradle 9 semantic versioning

### DIFF
--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -6,11 +6,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # wrapper = oldest supported version
+        # 8.11 = oldest supported version
+        # wrapper = supposed to be the oldest supported version but actually runs current
         # current = latest stable version
         # release-candidate = next stable version
         # nightly = latest development version
-        gradle-version: ["wrapper", "current", "release-candidate", "nightly"]
+        gradle-version: ["8.11", "wrapper", "current", "release-candidate", "nightly"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -22,10 +22,10 @@ jobs:
         with:
             gradle-version: ${{ matrix.gradle-version }}
       - name: Build Plugin
-        run: ./gradlew build
+        run: gradle build
       - name: Sample Analysis
         working-directory: sample
-        run: ../gradlew graphAnalysis
+        run: gradle graphAnalysis
       - name: Sample Inspection
         working-directory: sample
-        run: ../gradlew :app:graphInspection
+        run: gradle :app:graphInspection

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ org.gradle.caching=true
 org.gradle.parallel=true
 org.gradle.configuration-cache=true
 org.gradle.unsafe.isolated-projects=true
-version=1.1.0
+version=1.1.1

--- a/src/main/kotlin/com/ebay/plugins/graph/analytics/GraphAnalyticsPlugin.kt
+++ b/src/main/kotlin/com/ebay/plugins/graph/analytics/GraphAnalyticsPlugin.kt
@@ -13,7 +13,6 @@ import org.gradle.api.attributes.Attribute
 import org.gradle.api.initialization.Settings
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskProvider
-import org.gradle.util.GradleVersion
 import org.jgrapht.graph.DefaultDirectedGraph
 import org.jgrapht.nio.DefaultAttribute
 
@@ -33,10 +32,14 @@ internal class GraphAnalyticsPlugin : Plugin<Any> {
 
     private fun applySettings(settings: Settings) {
         // Verify Gradle version compatibility
-        if (GradleVersion.current() < GradleVersion.version(GRADLE_VERSION_MINIMUM)) {
-            throw GradleException("GraphAnalyticsPlugin requires Gradle 8.11 or later " +
-                    "(was: ${settings.gradle.gradleVersion})"
-            )
+        val (major, minor) = settings.gradle.gradleVersion
+            .substringBefore("-") // Remove any qualifier like `-rc-1`
+            .split('.')
+            .take(2)
+        if (major.toInt() < GRADLE_VERSION_MAJOR || minor.toInt() < GRADLE_VERSION_MINOR) {
+            throw GradleException("GraphAnalyticsPlugin requires Gradle " +
+                    "$GRADLE_VERSION_MAJOR.$GRADLE_VERSION_MINOR or later " +
+                    "(was: ${settings.gradle.gradleVersion})")
         }
 
         // Apply the plugin to all projects
@@ -345,7 +348,8 @@ internal class GraphAnalyticsPlugin : Plugin<Any> {
     }
 
     companion object {
-        private const val GRADLE_VERSION_MINIMUM = "8.11"
+        private const val GRADLE_VERSION_MAJOR = 8
+        private const val GRADLE_VERSION_MINOR = 11
 
         const val EXTENSION_NAME = "graphAnalytics"
         const val TASK_GROUP = "graph analytics"

--- a/src/main/kotlin/com/ebay/plugins/graph/analytics/GraphAnalyticsPlugin.kt
+++ b/src/main/kotlin/com/ebay/plugins/graph/analytics/GraphAnalyticsPlugin.kt
@@ -34,8 +34,8 @@ internal class GraphAnalyticsPlugin : Plugin<Any> {
     private fun applySettings(settings: Settings) {
         // Verify Gradle version compatibility
         if (GradleVersion.current() < GradleVersion.version(GRADLE_VERSION_MINIMUM)) {
-            throw GradleException("GraphAnalyticsPlugin requires Gradle 8.11 or later " +
-                    "(was: ${settings.gradle.gradleVersion})"
+            throw GradleException("GraphAnalyticsPlugin requires Gradle $GRADLE_VERSION_MINIMUM " +
+                    "or later (was: ${settings.gradle.gradleVersion})"
             )
         }
 

--- a/src/main/kotlin/com/ebay/plugins/graph/analytics/GraphAnalyticsPlugin.kt
+++ b/src/main/kotlin/com/ebay/plugins/graph/analytics/GraphAnalyticsPlugin.kt
@@ -13,6 +13,7 @@ import org.gradle.api.attributes.Attribute
 import org.gradle.api.initialization.Settings
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskProvider
+import org.gradle.util.GradleVersion
 import org.jgrapht.graph.DefaultDirectedGraph
 import org.jgrapht.nio.DefaultAttribute
 
@@ -32,14 +33,10 @@ internal class GraphAnalyticsPlugin : Plugin<Any> {
 
     private fun applySettings(settings: Settings) {
         // Verify Gradle version compatibility
-        val (major, minor) = settings.gradle.gradleVersion
-            .substringBefore("-") // Remove any qualifier like `-rc-1`
-            .split('.')
-            .take(2)
-        if (major.toInt() < GRADLE_VERSION_MAJOR || minor.toInt() < GRADLE_VERSION_MINOR) {
-            throw GradleException("GraphAnalyticsPlugin requires Gradle " +
-                    "$GRADLE_VERSION_MAJOR.$GRADLE_VERSION_MINOR or later " +
-                    "(was: ${settings.gradle.gradleVersion})")
+        if (GradleVersion.current() < GradleVersion.version(GRADLE_VERSION_MINIMUM)) {
+            throw GradleException("GraphAnalyticsPlugin requires Gradle 8.11 or later " +
+                    "(was: ${settings.gradle.gradleVersion})"
+            )
         }
 
         // Apply the plugin to all projects
@@ -348,8 +345,7 @@ internal class GraphAnalyticsPlugin : Plugin<Any> {
     }
 
     companion object {
-        private const val GRADLE_VERSION_MAJOR = 8
-        private const val GRADLE_VERSION_MINOR = 11
+        private const val GRADLE_VERSION_MINIMUM = "8.11"
 
         const val EXTENSION_NAME = "graphAnalytics"
         const val TASK_GROUP = "graph analytics"


### PR DESCRIPTION
When attempting to run with Gradle 9:
```
Caused by: org.gradle.api.GradleException: GraphAnalyticsPlugin requires Gradle 8.11 or later (was: 9.0.0-rc-1)
```

This PR changes the versin parsing.