### PR TITLE
Ensure that dependencies added in afterEvaluate are correctly picked up

### DIFF
--- a/src/main/kotlin/com/ebay/plugins/graph/analytics/GraphAnalyticsPlugin.kt
+++ b/src/main/kotlin/com/ebay/plugins/graph/analytics/GraphAnalyticsPlugin.kt
@@ -246,8 +246,11 @@ internal class GraphAnalyticsPlugin : Plugin<Any> {
                     }
                 }
 
-                val projectDependencies = config.allDependencies.filterIsInstance<ProjectDependency>()
-                projectDependencies.map { it.path }.forEach { depProjectPath ->
+                config.allDependencies.configureEach { dependency ->
+                    if (dependency !is ProjectDependency) {
+                        return@configureEach
+                    }
+                    val depProjectPath = dependency.path
                     addDependency(
                         project = project,
                         configuration =  dependenciesConfig,


### PR DESCRIPTION
Uses lazy terminal operator.

This fixes issues where plugin code in `afterEvaluate` blocks that add additional dependencies were not having those dependencies represented reliably in the graph.