### PR TITLE
Onboard to the OSS Community Develocity Instance

### DIFF
--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -23,6 +23,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v5
         with:
             gradle-version: ${{ matrix.gradle-version }}
+            develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
       - name: Build Plugin
         run: gradle build
       - name: Sample Analysis

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,8 @@ jobs:
           java-version: 17
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
+        with:
+          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
       - name: Build Plugin
         env:
           GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 # Graph Analytics Plugin
 
+[![Revved up by Develocity](https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A)](https://community.develocity.cloud/scans?search.rootProjectNames=graph-analytics-plugin)
+
 ## About This Project
 
 This [Gradle](https://gradle.org/) plugin was designed to be used in multi-module

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,7 +7,8 @@ pluginManagement {
 }
 
 plugins {
-    id("com.gradle.develocity") version("4.0.2")
+    id("com.gradle.develocity") version("4.5.0")
+    id("com.gradle.common-custom-user-data-gradle-plugin") version("2.8.0")
 }
 
 dependencyResolutionManagement {
@@ -19,9 +20,29 @@ dependencyResolutionManagement {
 
 rootProject.name = "graph-analytics-plugin"
 
+val isCI = System.getenv("CI") != null
+
 develocity {
+    server = "https://community.develocity.cloud"
+    projectId = "ebay"
     buildScan {
-        termsOfUseUrl.set("https://gradle.com/help/legal-terms-of-use")
-        termsOfUseAgree.set("yes")
+        uploadInBackground = !isCI
+        publishing.onlyIf { it.isAuthenticated }
+        obfuscation {
+            ipAddresses { addresses -> addresses.map { _ -> "0.0.0.0" } }
+        }
+    }
+}
+
+buildCache {
+    local {
+        isEnabled = true
+    }
+
+    remote(develocity.buildCache) {
+        isEnabled = true
+        // Check access key presence to avoid build cache errors on PR builds when access key is not present
+        val accessKey = System.getenv("DEVELOCITY_ACCESS_KEY")
+        isPush = isCI && accessKey != null
     }
 }


### PR DESCRIPTION
# Onboard to the OSS Community Develocity Instance

This PR adds [Develocity](https://gradle.com/develocity) Build Scan® and Build Cache support
for this project, publishing to the **OSS Community Develocity Instance** at
<https://community.develocity.cloud> under project ID `ebay`.

## What this PR adds

- The Develocity Gradle plugin and the Common Custom User Data Gradle
  plugin, applied at the latest released versions.
- `settings.gradle.kts` pointing the build at `https://community.develocity.cloud` and
  associating builds with project `ebay`.
- A "Revved up by Develocity" badge in the README linking to the filtered Build Scan list
  for this project's root project name.
- A setup step in each GitHub Actions workflow that runs the build, so CI publishes Build
  Scans automatically using a short-lived access token.

## Step 1 — Get an access key for `community.develocity.cloud`

Build Scan publishing **and** Build Cache writes from CI need a Develocity access key.

1. Visit <https://community.develocity.cloud>.
2. **Sign in as the CI service account that the Develocity Solutions team has provisioned
   for your project** — that account was shared with you out-of-band when this onboarding
   was set up. The access key inherits that account's project memberships and permissions,
   which is exactly what you want for CI.
3. From the user menu in the top-right, open **My settings** → **Access keys**.
4. Click **Generate access key**, give it a description (e.g. `GitHub Actions`), and copy
   the generated key. Keep this tab open until you complete Step 2 — the key is only
   shown once.

## Step 2 — Set the GitHub Actions secret on this repository

CI uses a repository secret named `DEVELOCITY_ACCESS_KEY` to authenticate to
`community.develocity.cloud`.

1. Open this repository on GitHub.
2. Click **Settings**.
3. In the left sidebar, click **Secrets and variables** → **Actions**.
4. Click **New repository secret**. (If a `DEVELOCITY_ACCESS_KEY` secret already exists,
   click its **Update** button instead.)
5. Set **Name** to:

   ```
   DEVELOCITY_ACCESS_KEY
   ```

6. Set **Secret** to the value below, replacing `PASTE_THE_ACCESS_KEY_FROM_STEP_1_HERE`
   with the key you copied in Step 1:

   ```
   community.develocity.cloud=PASTE_THE_ACCESS_KEY_FROM_STEP_1_HERE
   ```

   The `community.develocity.cloud=` prefix is **required** — without the host name, the
   access key is silently ignored. This is the most common point of failure when
   onboarding, so please double-check the format.
7. Click **Add secret** (or **Update secret**).

## Step 3 — Provision an access key for your local builds

Developers building this project locally should provision an access key for
`community.develocity.cloud` so their Build Scans publish and they get reads
from the remote Build Cache. The Develocity Gradle plugin's
`provisionDevelocityAccessKey` task does this in a single command — it opens
the browser, asks the developer to confirm, and writes the key to
`~/.gradle/develocity/keys.properties` automatically.

**Before running this command**, sign out of `community.develocity.cloud` in
your browser (or use a private/incognito window) so the access key gets
associated with **your personal account**, not the CI service account you
signed in as for Step 1.

```
./gradlew provisionDevelocityAccessKey
```

## Note on the CI run on this PR

This PR was prepared from a fork. Forks can't read your repository's secrets, so the
workflow run on this PR cannot publish to `community.develocity.cloud` even after you set
the secret in Step 2.

If you want CI verification before merging, push the branch
`dv/onboard-oss-community-develocity-instance` to a temporary branch on **this** repo (not
the fork) and re-run the workflow there — it will pick up the secret and publish a Build
Scan.

After merging, every CI run **on this repository** will publish a Build Scan to
<https://community.develocity.cloud>. CI runs from forks of this repository will not (forks
don't have access to the secret either), and that's expected.
